### PR TITLE
Update BankDefault.lua

### DIFF
--- a/BankDefault.lua
+++ b/BankDefault.lua
@@ -30,13 +30,11 @@ end
 function BankDefault.OnBankOpen(event, bankBag)
     --  if bankBag ~= BANK_BAG then return end
     d("Viewing bank bag", bankBag)
-    if IsBankOpen() then
-        local bag = GetBankingBag()
+        local bag = bankBag or GetBankingBag()
         local size = GetBagSize(bag)
-        d("The current bank can hold " .. size .. " items.")
+        d(string.format("The current bank %s can hold %d items", tostring(bag), size))
         d("Saving your money won't earn you interest in Tamriel, but guards can only confiscate the gold you have on your person.")
         zo_callLater(function () selectDeposit() end,3000)
-    end
 end
 
 function selectDeposit()


### PR DESCRIPTION
1. IsBankOpen() is not needed as the event fires IF the bank opens, so it IS open.
2. Showed you string.format for %s string and %d integer placeholders, debug message example
2. Event_bank_open already provides the opened bankBag in parameter bankBag so no need to use GetBankingBag() here.
Changed the line to only use it as "fallback" if bankBag is empty (but GetBankingBag() should return nil as well then :-) ).